### PR TITLE
아이템 소비(Consume) 시스템 구현

### DIFF
--- a/Content/__ExternalActors__/ThirdPerson/Maps/ThirdPersonMap/2/TW/9T0E5CTK82UTBMPI0HQ6K5.uasset
+++ b/Content/__ExternalActors__/ThirdPerson/Maps/ThirdPersonMap/2/TW/9T0E5CTK82UTBMPI0HQ6K5.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59fb5c1e5b6653a2adf46dad572febe729b109c3a011b72171562f9892420f21
-size 5256

--- a/Content/__ExternalActors__/ThirdPerson/Maps/ThirdPersonMap/D/3A/J4O05KGXY6HZ6XGXVMNCGR.uasset
+++ b/Content/__ExternalActors__/ThirdPerson/Maps/ThirdPersonMap/D/3A/J4O05KGXY6HZ6XGXVMNCGR.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6687bbf2979d17146471cfee86f05ad041e1e124fba43bfa17b8f12ddd88dae4
-size 5244

--- a/Plugins/Inventory/Content/Items/BP_Inv_Potion_Small_Blue.uasset
+++ b/Plugins/Inventory/Content/Items/BP_Inv_Potion_Small_Blue.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e39a504df5bcac7696bdbcb7bf83ec0465282cf1aa281f3d418b338bc04ac3a4
-size 34388
+oid sha256:b84524d246a36e6532ce3640a6f8ebc14ba205b3dff41d37fcdf4ceab50f89e0
+size 34660

--- a/Plugins/Inventory/Content/Items/BP_Inv_Potion_Small_Red.uasset
+++ b/Plugins/Inventory/Content/Items/BP_Inv_Potion_Small_Red.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f72f392076d4a8acea746d15cd7559e353b154cb5336c65ec333bdaa0464f317
-size 34422
+oid sha256:dbde949eb2da0bb32878256e8842eae5e030e95aed728178b74a3557ff788ea7
+size 34705

--- a/Plugins/Inventory/Source/Inventory/Private/InventoryManagement/Components/Inv_InventoryComponent.cpp
+++ b/Plugins/Inventory/Source/Inventory/Private/InventoryManagement/Components/Inv_InventoryComponent.cpp
@@ -99,6 +99,30 @@ void UInv_InventoryComponent::Server_DropItem_Implementation(UInv_InventoryItem*
 	SpawnDroppedItem(Item, StackCount);
 }
 
+void UInv_InventoryComponent::Server_ConsumeItem_Implementation(UInv_InventoryItem* Item)
+{
+	// 아이템의 스택 수량을 1 감소시킵니다
+	const int32 NewStackCount = Item->GetTotalStackCount() - 1;
+
+	// 스택이 0 이하가 되면 인벤토리에서 아이템을 완전히 제거합니다
+	if (NewStackCount <= 0)
+	{
+		InventoryList.RemoveEntry(Item);
+	}
+	else
+	{
+		// 스택이 남아있으면 새로운 수량으로 업데이트합니다
+		Item->SetTotalStackCount(NewStackCount);
+	}
+
+	// 아이템의 소비 가능 프래그먼트를 찾아서 OnConsume을 호출합니다
+	// 이를 통해 체력 회복, 마나 회복 등의 효과가 실행됩니다
+	if (FInv_ConsumableFragment* ConsumableFragment = Item->GetItemManifestMutable().GetFragmentOfTypeMutable<FInv_ConsumableFragment>())
+	{
+		ConsumableFragment->OnConsume(OwningController.Get());
+	}
+}
+
 void UInv_InventoryComponent::ToggleInventoryMenu()
 {
 	if (bInventoryMenuOpen)

--- a/Plugins/Inventory/Source/Inventory/Private/Items/Fragments/Inv_FragmentTags.cpp
+++ b/Plugins/Inventory/Source/Inventory/Private/Items/Fragments/Inv_FragmentTags.cpp
@@ -15,4 +15,7 @@ namespace FragmentTags
 
 	/** 스택 기능 프래그먼트를 식별하기 위한 스택 가능 프래그먼트 태그 정의 */
 	UE_DEFINE_GAMEPLAY_TAG(StackableFragment, "FragmentTags.StackableFragment")
+
+	/** 소비 가능 프래그먼트를 식별하기 위한 소비 가능 프래그먼트 태그 정의 */
+	UE_DEFINE_GAMEPLAY_TAG(ConsumableFragment, "FragmentTags.ConsumableFragment")
 }

--- a/Plugins/Inventory/Source/Inventory/Private/Items/Fragments/Inv_ItemFragment.cpp
+++ b/Plugins/Inventory/Source/Inventory/Private/Items/Fragments/Inv_ItemFragment.cpp
@@ -4,3 +4,24 @@
  */
 
 #include "Items/Fragments/Inv_ItemFragment.h"
+
+
+void FInv_HealthPotionFragment::OnConsume(APlayerController* PC)
+{
+    // 실제 구현에서는 다음 중 하나를 사용하여 체력을 회복시킵니다:
+    // - PC 또는 PC->GetPawn()에서 스탯 컴포넌트를 가져와서 체력 증가
+    // - Ability System Component를 가져와서 Gameplay Effect 적용
+    // - Healing() 인터페이스 함수 호출
+
+    // 현재는 디버그 메시지만 출력합니다 (테스트/프로토타입 용도)
+    GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("Health Potion consumed! Healing by: %f"), HealAmount));
+}
+
+void FInv_ManaPotionFragment::OnConsume(APlayerController* PC)
+{
+    // 실제 구현에서는 프로젝트의 마나 시스템에 맞게 마나를 회복시킵니다
+    // 예: Ability System Component를 통한 마나 회복 Gameplay Effect 적용
+
+    // 현재는 디버그 메시지만 출력합니다 (테스트/프로토타입 용도)
+    GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Blue, FString::Printf(TEXT("Mana Potion consumed! Mana replenished by: %f"), ManaAmount));
+}

--- a/Plugins/Inventory/Source/Inventory/Public/InventoryManagement/Components/Inv_InventoryComponent.h
+++ b/Plugins/Inventory/Source/Inventory/Public/InventoryManagement/Components/Inv_InventoryComponent.h
@@ -75,6 +75,15 @@ public:
 	void Server_DropItem(UInv_InventoryItem* Item, int32 StackCount);
 
 	/**
+	 * 서버 RPC: 인벤토리에서 아이템을 소비합니다
+	 * 스택 수량을 1 감소시키고, 소비 가능 프래그먼트의 OnConsume을 호출합니다
+	 * 스택이 0이 되면 인벤토리에서 아이템을 제거합니다
+	 * @param Item 소비할 인벤토리 아이템
+	 */
+	UFUNCTION(Server, Reliable)
+	void Server_ConsumeItem(UInv_InventoryItem* Item);
+	
+	/**
 	 * 인벤토리 메뉴를 열거나 닫습니다
 	 */
 	void ToggleInventoryMenu();

--- a/Plugins/Inventory/Source/Inventory/Public/Items/Fragments/Inv_FragmentTags.h
+++ b/Plugins/Inventory/Source/Inventory/Public/Items/Fragments/Inv_FragmentTags.h
@@ -16,4 +16,7 @@ namespace FragmentTags
 
 	/** 스택 가능 프래그먼트 태그 (FragmentTags.StackableFragment) - 아이템 스택 기능 활성화 */
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(StackableFragment)
+
+	/** 소비 가능 프래그먼트 태그 (FragmentTags.ConsumableFragment) - 아이템 소비 기능 활성화 */
+	UE_DECLARE_GAMEPLAY_TAG_EXTERN(ConsumableFragment)
 }

--- a/Plugins/Inventory/Source/Inventory/Public/Items/Fragments/Inv_ItemFragment.h
+++ b/Plugins/Inventory/Source/Inventory/Public/Items/Fragments/Inv_ItemFragment.h
@@ -5,6 +5,7 @@
 
 #include "Inv_ItemFragment.generated.h"
 
+class APlayerController;
 /**
  * 아이템 컴포지션 시스템의 기본 프래그먼트 구조체
  * 아이템은 여러 프래그먼트로 구성되며, 각 프래그먼트는 특정 동작이나 속성을 정의합니다
@@ -48,7 +49,7 @@ struct FInv_ItemFragment
 private:
 
 	/** 이 프래그먼트 타입을 고유하게 식별하는 GameplayTag */
-	UPROPERTY(EditAnywhere, Category = "Inventory")
+	UPROPERTY(EditAnywhere, Category = "Inventory", meta = (Categories = "FragmentTags"))
 	FGameplayTag FrgmentTag = FGameplayTag::EmptyTag;
 };
 
@@ -159,4 +160,64 @@ private:
 	/** 이 스택의 현재 아이템 개수. 기본값은 1 */
 	UPROPERTY(EditAnywhere, Category = "Inventory")
 	int32 StackCount{1};
+};
+
+/**
+ * 소비 가능 아이템의 기본 프래그먼트
+ * 아이템이 소비될 때의 동작을 정의합니다
+ * 파생 구조체에서 OnConsume을 오버라이드하여 구체적인 소비 효과를 구현합니다
+ */
+USTRUCT(BlueprintType)
+struct FInv_ConsumableFragment : public FInv_ItemFragment
+{
+	GENERATED_BODY()
+
+	/**
+	 * 아이템이 소비될 때 호출되는 가상 함수
+	 * 파생 구조체에서 오버라이드하여 체력 회복, 마나 회복 등의 효과를 구현합니다
+	 * @param PC 아이템을 소비하는 플레이어 컨트롤러
+	 */
+	virtual void OnConsume(APlayerController* PC) {}
+};
+
+/**
+ * 체력 회복 포션 프래그먼트
+ * 소비 시 플레이어의 체력을 회복시키는 기능을 제공합니다
+ */
+USTRUCT(BlueprintType)
+struct FInv_HealthPotionFragment : public FInv_ConsumableFragment
+{
+	GENERATED_BODY()
+
+	/** 이 포션이 회복시키는 체력 수치. 기본값은 20 */
+	UPROPERTY(EditAnywhere, Category = "Inventory")
+	float HealAmount = 20.f;
+
+	/**
+	 * 체력 포션을 소비합니다
+	 * 플레이어의 체력을 HealAmount만큼 회복시킵니다
+	 * @param PC 아이템을 소비하는 플레이어 컨트롤러
+	 */
+	virtual void OnConsume(APlayerController* PC) override;
+};
+
+/**
+ * 마나 회복 포션 프래그먼트
+ * 소비 시 플레이어의 마나를 회복시키는 기능을 제공합니다
+ */
+USTRUCT(BlueprintType)
+struct FInv_ManaPotionFragment : public FInv_ConsumableFragment
+{
+	GENERATED_BODY()
+
+	/** 이 포션이 회복시키는 마나 수치. 기본값은 20 */
+	UPROPERTY(EditAnywhere, Category = "Inventory")
+	float ManaAmount = 20.f;
+
+	/**
+	 * 마나 포션을 소비합니다
+	 * 플레이어의 마나를 ManaAmount만큼 회복시킵니다
+	 * @param PC 아이템을 소비하는 플레이어 컨트롤러
+	 */
+	virtual void OnConsume(APlayerController* PC) override;
 };

--- a/Plugins/Inventory/Source/Inventory/Public/Items/Manifest/Inv_ItemManifest.h
+++ b/Plugins/Inventory/Source/Inventory/Public/Items/Manifest/Inv_ItemManifest.h
@@ -82,7 +82,7 @@ private:
 	EInv_ItemCategory ItemCategory {EInv_ItemCategory::None};
 
 	/** 이 아이템의 고유 타입을 나타내는 GameplayTag (예: Axe, Sword, Potion 등) */
-	UPROPERTY(EditAnywhere, Category = "Inventory")
+	UPROPERTY(EditAnywhere, Category = "Inventory", meta = (Categories = "GameItems"))
 	FGameplayTag ItemType;
 
 	/** 월드에 스폰될 픽업 액터의 클래스 (드롭되거나 배치될 때 사용) */


### PR DESCRIPTION
## Summary

- 아이템 우클릭 팝업 메뉴를 통한 아이템 소비 기능 구현
- Fragment 패턴을 활용한 확장 가능한 소비 시스템 설계
- 체력 포션 및 마나 포션 프래그먼트 구현
- 서버 권한 기반 네트워크 복제 지원
- Epic Games 코딩 표준에 맞는 주석 작성

## 주요 구현 사항

### 1. 소비 가능 프래그먼트 시스템
- `FInv_ConsumableFragment`: 소비 가능 아이템의 기본 프래그먼트
- `FInv_HealthPotionFragment`: 체력 회복 포션 (HealAmount 속성)
- `FInv_ManaPotionFragment`: 마나 회복 포션 (ManaAmount 속성)
- `OnConsume(APlayerController*)` 가상 함수로 확장 가능한 구조

### 2. 인벤토리 컴포넌트
- `Server_ConsumeItem(UInv_InventoryItem*)`: 서버 RPC 함수 추가
- 스택 수량 자동 감소 및 빈 스택 제거 처리
- ConsumableFragment 자동 검색 및 OnConsume 호출

### 3. UI 통합
- 그리드 아이템 우클릭 시 "Consume" 메뉴 옵션
- `UInv_InventoryGrid::OnPopUpMenuConsume` 구현
- 실시간 스택 카운트 UI 업데이트
- 멀티 셀 아이템의 왼쪽 상단 기준 스택 관리

### 4. 기타 개선사항
- 아이템 드롭 로직 최적화
- `RemoveEntry` 메서드 배열 변경 처리 버그 수정
- 아이템 팝업 슬롯 상호작용 기능 추가
- GameplayTag 메타데이터 카테고리 필터 추가

## 기술적 세부사항

**Fragment Pattern**: 컴포지션 기반 설계로 새로운 소비 효과 추가 시 기존 코드 수정 없이 확장 가능

**Network Replication**: Fast Array 기반 서버 권한 인벤토리 시스템과 통합

**Type Safety**: GameplayTag와 템플릿 기반 프래그먼트 검색으로 타입 안전성 보장

## Test plan

- [x] 체력 포션 소비 시 디버그 메시지 확인
- [x] 마나 포션 소비 시 디버그 메시지 확인
- [x] 스택 수량 감소 확인
- [x] 마지막 스택 소비 시 아이템 제거 확인
- [ ] 멀티플레이어 환경에서 복제 테스트
- [x] 멀티 셀 아이템의 소비 동작 확인
- [x] 우클릭 팝업 메뉴 UI 테스트

## 관련 이슈

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)